### PR TITLE
Bitblasting rotates and unsigned division / remainder

### DIFF
--- a/src/fol/utils.rs
+++ b/src/fol/utils.rs
@@ -1,7 +1,7 @@
 use super::{Term, op::DynOp};
 use std::ops::{ControlFlow, FromResidual, Try};
 use std::{
-    ops::{Deref, DerefMut, Index, IndexMut, Range, RangeInclusive, RangeTo},
+    ops::{Deref, DerefMut, Index, IndexMut, Range, RangeInclusive, RangeTo, RangeFrom},
     slice, vec,
 };
 
@@ -92,6 +92,14 @@ impl Index<RangeTo<usize>> for TermVec {
 
     #[inline]
     fn index(&self, index: RangeTo<usize>) -> &Self::Output {
+        self.data.index(index)
+    }
+}
+
+impl Index<RangeFrom<usize>> for TermVec {
+    type Output = [Term];
+    #[inline]
+    fn index(&self, index: RangeFrom<usize>) -> &Self::Output {
         self.data.index(index)
     }
 }


### PR DESCRIPTION
Added supports for bit-blasting Rol, Ror, Udiv and Urem.

Tested with `cerboter` using master branch of `rIC3` ([3c15882](https://github.com/gipsyh/rIC3/commit/3c158824719b873a5e2f8f84c7f7b7d655566635)), plus cherry-picking the most recent commit in `certifaiger` ([c3db864](https://github.com/gipsyh/rIC3/commit/c3db864868d58278c743377a2ef434988c3ceae6)).

Basic IC3 (`exec rIC3 -e ic3 "$@"`) shows no error with 10k cases fuzzed, but other configs, particularly
`ic3-inn`, show errors but these do not seem like caused by bit blasting.

More tests under way.