### PR TITLE
Bit blasting of remaining operators except {S,U}mulo

### DIFF
--- a/src/fol/op/core_op.rs
+++ b/src/fol/op/core_op.rs
@@ -231,6 +231,7 @@ fn eq_cnf_encode(dc: &mut DagCnf, terms: &[Lit]) -> Lit {
 }
 
 define_core_op!(Ult, 2, sort: bool_sort, bitblast: ult_bitblast, simplify: ult_simplify);
+define_core_op!(Usubo, 2, sort: bool_sort, bitblast: ult_bitblast, simplify: ult_simplify);
 fn ult_simplify(terms: &[Term]) -> TermResult {
     let x = &terms[0];
     let y = &terms[1];
@@ -563,6 +564,51 @@ fn add_bitblast(terms: &[TermVec]) -> TermVec {
     }
     res
 }
+define_core_op!(Sub, 2, bitblast: sub_bitblast);
+fn sub_bitblast(terms: &[TermVec]) -> TermVec {
+    let mut r;
+    let mut c = Term::bool_const(true);
+    let mut res = TermVec::new();
+    for (x, y) in terms[0].iter().zip(terms[1].iter()) {
+        (r, c) = full_adder(x, &!y, &c);
+        res.push(r);
+    }
+    res
+}
+
+define_core_op!(Uaddo, 2, sort: bool_sort, bitblast: uaddo_bitblast);
+fn uaddo_bitblast(terms: &[TermVec]) -> TermVec {
+    let mut x = terms[0].clone(); let mut y = terms[1].clone();
+    x.push(Term::bool_const(false));
+    y.push(Term::bool_const(false));
+    x = add_bitblast(&[x, y]);
+    [x[x.len()-1].clone()].into()
+}
+define_core_op!(Saddo, 2, sort: bool_sort, bitblast: saddo_bitblast);
+fn saddo_bitblast(terms: &[TermVec]) -> TermVec {
+    assert_eq!(terms.len(), 2);
+    let w  = terms[0].len();
+    let sx = &terms[0][w - 1]; // sign bits
+    let sy = &terms[1][w - 1];
+    let sum = add_bitblast(terms);
+    let ss  = &sum[w - 1];
+    let v1 = sx & sy & !ss;
+    let v2 = !sx & !sy & ss;
+    TermVec::from([v1 | v2])
+}
+define_core_op!(Ssubo, 2, sort: bool_sort, bitblast: ssubo_bitblast);
+fn ssubo_bitblast(terms: &[TermVec]) -> TermVec {
+    assert_eq!(terms.len(), 2);
+    let w  = terms[0].len();
+    let sx = &terms[0][w - 1];
+    let sy = &terms[1][w - 1];
+    // compute w-bit (x - y) discarding carry_out
+    let diff = sub_bitblast(terms);
+    let sr   = &diff[w - 1];
+    let v1 = sx & !sy & !sr;
+    let v2 = !sx &  sy &  sr;
+    TermVec::from([v1 | v2])
+}
 
 define_core_op!(Mul, 2, bitblast: mul_bitblast);
 fn mul_bitblast(terms: &[TermVec]) -> TermVec {
@@ -628,6 +674,26 @@ define_core_op!(Urem, 2, bitblast: urem_bitblast);
 fn urem_bitblast(terms: &[TermVec]) -> TermVec {
     let (_, r) = udiv_urem_bitblast(&terms[0], &terms[1]);
     r
+}
+
+// fn umulo_bitblast(terms: &[TermVec]) -> TermVec {
+//     let k = terms[0].len();
+//     if k == 1 { return TermVec::from([Term::bool_const(false)]); }
+//     let mut 
+//     for i in 0..w {
+//         let no_ofl = Term::new_op_fold(Or, terms)
+//     }
+// }
+
+define_core_op!(Sdivo, 2, sort: bool_sort, bitblast: sdivo_bitblast);
+fn sdivo_bitblast(terms: &[TermVec]) -> TermVec {
+    let div_by0 = Term::new_op_fold(And, terms[1].iter().map(|t| !t));
+    let w = terms[0].len();
+    assert!(w == terms[1].len());
+    let mneg_div_neg1 = Term::new_op_fold(And, &terms[1]) // -1
+        & Term::new_op_fold(And, terms[0][0..w-1].iter().map(|t| !t))
+        & &terms[0][w - 1]; // INT_MIN
+    TermVec::from([div_by0 | mneg_div_neg1])
 }
 
 define_core_op!(Read, 2, sort: read_sort, bitblast: read_bitblast);

--- a/src/fol/op/other_op.rs
+++ b/src/fol/op/other_op.rs
@@ -2,12 +2,6 @@ use super::Term;
 use super::define::define_non_core_op;
 use super::{Concat, Eq, Slt, Ult, Xor};
 
-define_non_core_op!(Neg, 1, neg_normalize);
-fn neg_normalize(terms: &[Term]) -> Term {
-    let term = &terms[0];
-    !term + term.mk_bv_const_one()
-}
-
 define_non_core_op!(Inc, 1, inc_normalize);
 fn inc_normalize(terms: &[Term]) -> Term {
     &terms[0] + terms[0].mk_bv_const_one()

--- a/src/fol/op/other_op.rs
+++ b/src/fol/op/other_op.rs
@@ -22,42 +22,45 @@ define_non_core_op!(Nand, 2, nand_normalize);
 fn nand_normalize(terms: &[Term]) -> Term {
     !(&terms[0] & &terms[1])
 }
-
 define_non_core_op!(Nor, 2, nor_normalize);
 fn nor_normalize(terms: &[Term]) -> Term {
     !(&terms[0] | &terms[1])
+}
+define_non_core_op!(Xnor, 2, xnor_normalize);
+fn xnor_normalize(terms: &[Term]) -> Term {
+    !Term::new_op(Xor, terms)
 }
 
 define_non_core_op!(Iff, 2, iff_normalize);
 fn iff_normalize(terms: &[Term]) -> Term {
     terms[0].op1(Eq, &terms[1])
 }
-
-define_non_core_op!(Redand, 1, redand_normalize);
-fn redand_normalize(terms: &[Term]) -> Term {
-    let ones = terms[0].mk_bv_const_ones();
-    terms[0].op1(Eq, &ones)
-}
-
-define_non_core_op!(Redor, 1, redor_normalize);
-fn redor_normalize(terms: &[Term]) -> Term {
-    let zero = terms[0].mk_bv_const_zero();
-    !terms[0].op1(Eq, &zero)
-}
-
-define_non_core_op!(Neq, 2, neq_normalize);
-fn neq_normalize(terms: &[Term]) -> Term {
-    !Term::new_op(Eq, terms)
-}
-
 define_non_core_op!(Implies, 2, implies_normalize);
 fn implies_normalize(terms: &[Term]) -> Term {
     !&terms[0] | &terms[1]
 }
 
-define_non_core_op!(Xnor, 2, xnor_normalize);
-fn xnor_normalize(terms: &[Term]) -> Term {
-    !Term::new_op(Xor, terms)
+// redand: x = 111111111
+define_non_core_op!(Redand, 1, redand_normalize);
+fn redand_normalize(terms: &[Term]) -> Term {
+    let ones = terms[0].mk_bv_const_ones();
+    terms[0].op1(Eq, &ones)
+}
+// redor: x != 00000000
+define_non_core_op!(Redor, 1, redor_normalize);
+fn redor_normalize(terms: &[Term]) -> Term {
+    let zero = terms[0].mk_bv_const_zero();
+    !terms[0].op1(Eq, &zero)
+}
+// udivo: y != 00000000
+define_non_core_op!(Udivo, 2, udivo_normalize);
+fn udivo_normalize(terms: &[Term]) -> Term {
+    let zero = terms[1].mk_bv_const_zero();
+    !terms[1].op1(Eq, &zero)
+}
+define_non_core_op!(Neq, 2, neq_normalize);
+fn neq_normalize(terms: &[Term]) -> Term {
+    !Term::new_op(Eq, terms)
 }
 
 define_non_core_op!(Uext, 2, uext_normalize);
@@ -97,9 +100,4 @@ fn slte_normalize(terms: &[Term]) -> Term {
 define_non_core_op!(Sgte, 2, sgte_normalize);
 fn sgte_normalize(terms: &[Term]) -> Term {
     !Term::new_op(Slt, terms)
-}
-
-define_non_core_op!(Sub, 2, sub_normalize);
-fn sub_normalize(terms: &[Term]) -> Term {
-    &terms[0] + -&terms[1]
 }


### PR DESCRIPTION
Sdiv and Srem are tested with `cerboter`, but due to `btorsim` being [unable to](https://github.com/hwmcc/btor2tools/blob/master/src/btorsim/btorsim.cpp#L290-L305) simulate the overflow operators, the rest remain untested.

```c
    case BTOR2_TAG_saddo:
    case BTOR2_TAG_sdivo:
    case BTOR2_TAG_smulo:
    case BTOR2_TAG_ssubo:
    case BTOR2_TAG_uaddo:
    case BTOR2_TAG_umulo:
    case BTOR2_TAG_usubo:
    default:
      die ("parse error in '%s' at line %" PRId64 ": unsupported '%" PRId64
           " %s%s'",
           model_path,
           l->lineno,
           l->id,
           l->name,
           l->nargs ? " ..." : "");
      break;
``` 

The amazing coder named ChatGPT says they are correct 🤪. Further reviews or edits may be needed.