### PR TITLE
Fix wrong sort derivation in FolOp::sort() for Ult and Slt

### DIFF
--- a/src/fol/op.rs
+++ b/src/fol/op.rs
@@ -171,8 +171,6 @@ impl FolOp {
             | FolOp::And
             | FolOp::Or
             | FolOp::Xor
-            | FolOp::Ult
-            | FolOp::Slt
             | FolOp::Sll
             | FolOp::Srl
             | FolOp::Sra
@@ -188,7 +186,7 @@ impl FolOp {
             | FolOp::Srem
             | FolOp::Smod
             | FolOp::Write => terms[0].sort(),
-            FolOp::Redxor | FolOp::Eq | FolOp::Ors | FolOp::Ands => Sort::Bv(1),
+            FolOp::Redxor | FolOp::Eq | FolOp::Ors | FolOp::Ands | FolOp::Ult | FolOp::Slt => Sort::Bv(1),
             FolOp::Ite => terms[1].sort(),
             FolOp::Concat | FolOp::Sext => Sort::Bv(terms[0].bv_len() + terms[1].bv_len()),
             FolOp::Slice => Sort::Bv(terms[1].bv_len() - terms[2].bv_len() + 1),

--- a/src/fol/test.rs
+++ b/src/fol/test.rs
@@ -187,3 +187,94 @@ fn test_simplify_not_not() {
     let mut map = GHashMap::new();
     assert_eq!(expr.simplify(&mut map), x);
 }
+
+// Regression tests for the Ult/Slt sort bug.
+//
+// Before the fix, FolOp::sort() returned terms[0].sort() (the operand width)
+// for Ult and Slt instead of Sort::Bv(1).  The BTOR2 parser asserts that the
+// sort computed by new_op matches the sort declared in the BTOR2 file; for any
+// N-bit (N > 1) comparison this assertion would fire immediately on parse.
+//
+// Minimal reproducer BTOR2:
+//   1 sort bitvec 1
+//   2 sort bitvec 8
+//   3 input 2 a
+//   4 input 2 b
+//   5 ult 1 3 4    ← panicked here before the fix
+//   6 bad 5
+
+#[test]
+fn test_ult_result_sort_is_one_bit() {
+    // Operands are 8-bit; result must be 1-bit regardless.
+    let x = Term::new_var(Sort::Bv(8));
+    let y = Term::new_var(Sort::Bv(8));
+    let ult = x.op1(super::op::FolOp::Ult, &y);
+    assert_eq!(
+        ult.sort(),
+        Sort::Bv(1),
+        "ult of 8-bit operands must have sort bitvec 1"
+    );
+}
+
+#[test]
+fn test_slt_result_sort_is_one_bit() {
+    let x = Term::new_var(Sort::Bv(8));
+    let y = Term::new_var(Sort::Bv(8));
+    let slt = x.op1(super::op::FolOp::Slt, &y);
+    assert_eq!(
+        slt.sort(),
+        Sort::Bv(1),
+        "slt of 8-bit operands must have sort bitvec 1"
+    );
+}
+
+#[test]
+fn test_ult_simulate() {
+    // Strings are MSB-first; LboolVec::from reverses them to LSB-first internally.
+    let x = Term::new_var(Sort::Bv(8));
+    let y = Term::new_var(Sort::Bv(8));
+    let ult = x.op1(super::op::FolOp::Ult, &y);
+
+    // 5 < 10 → true
+    let mut val = GHashMap::new();
+    val.insert(x.clone(), bv_val("00000101")); // 5
+    val.insert(y.clone(), bv_val("00001010")); // 10
+    assert_bv_eq(&ult.simulate(&mut val), "1");
+
+    // 10 < 5 → false
+    let mut val = GHashMap::new();
+    val.insert(x.clone(), bv_val("00001010")); // 10
+    val.insert(y.clone(), bv_val("00000101")); // 5
+    assert_bv_eq(&ult.simulate(&mut val), "0");
+
+    // 5 < 5 → false (equal, not strictly less)
+    let mut val = GHashMap::new();
+    val.insert(x.clone(), bv_val("00000101")); // 5
+    val.insert(y.clone(), bv_val("00000101")); // 5
+    assert_bv_eq(&ult.simulate(&mut val), "0");
+}
+
+#[test]
+fn test_slt_simulate() {
+    let x = Term::new_var(Sort::Bv(8));
+    let y = Term::new_var(Sort::Bv(8));
+    let slt = x.op1(super::op::FolOp::Slt, &y);
+
+    // -1 (0xFF) < 1 (0x01) → true (signed)
+    let mut val = GHashMap::new();
+    val.insert(x.clone(), bv_val("11111111")); // -1
+    val.insert(y.clone(), bv_val("00000001")); //  1
+    assert_bv_eq(&slt.simulate(&mut val), "1");
+
+    // 1 < -1 → false (signed)
+    let mut val = GHashMap::new();
+    val.insert(x.clone(), bv_val("00000001")); //  1
+    val.insert(y.clone(), bv_val("11111111")); // -1
+    assert_bv_eq(&slt.simulate(&mut val), "0");
+
+    // 5 < 10 → true (positive values, same as unsigned)
+    let mut val = GHashMap::new();
+    val.insert(x.clone(), bv_val("00000101")); // 5
+    val.insert(y.clone(), bv_val("00001010")); // 10
+    assert_bv_eq(&slt.simulate(&mut val), "1");
+}


### PR DESCRIPTION
This commit fixes a bug in FolOp::sort() which derived the sort terms[0].sort() for Op FolOp::Ult | FolOp::Slt.
The type, however, should be Sort::Bv(1).

Reproducer: This causes btor-rs to crash with the assertion
```
let res = Term::new_op(op, &operand);
assert!(res.sort().eq(sort));   // <— the panic site
```
when parsing
```
1 sort bitvec 1
2 sort bitvec 8
3 input 2 a
4 input 2 b
5 ult 1 3 4
6 bad 5
```

--- Vincent Quentin Ulitzsch